### PR TITLE
Env cleanup

### DIFF
--- a/20250401-kubecon-london/workshop/00-prerequisites/01-install.sh
+++ b/20250401-kubecon-london/workshop/00-prerequisites/01-install.sh
@@ -3,7 +3,7 @@
 set -o nounset
 set -o pipefail
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
 export GOOS="$( uname | tr '[:upper:]' '[:lower:]' | grep -E 'linux|darwin' )"
 export GOARCH="$( uname -m | sed 's/x86_64/amd64/ ; s/aarch64/arm64/' | grep -E 'amd64|arm64' )"
 
@@ -12,47 +12,47 @@ set -o errexit
 [[ -n "${GOOS}" ]] || { echo "Unsupported OS: $(uname)" 1>&2 ; exit 1 ; }
 [[ -n "${GOARCH}" ]] || { echo "Unsupported platform: $(uname -m)" 1>&2 ; exit 1 ; }
 
-if [[ ! -f "${workshop_root}/bin/.checkpoint-kcp" ]]; then
+if [[ ! -f "${WORKSHOP_ROOT}/bin/.checkpoint-kcp" ]]; then
   echo "🚀 Downloading kcp"
   curl -L "https://github.com/kcp-dev/kcp/releases/download/v0.26.1/kcp_0.26.1_${GOOS}_${GOARCH}.tar.gz" \
-    | tar -C "${workshop_root}" -xzf - bin/kcp
-  touch "${workshop_root}/bin/.checkpoint-kcp"
+    | tar -C "${WORKSHOP_ROOT}" -xzf - bin/kcp
+  touch "${WORKSHOP_ROOT}/bin/.checkpoint-kcp"
 fi
 
-if [[ ! -f "${workshop_root}/bin/.checkpoint-api-syncagent" ]]; then
+if [[ ! -f "${WORKSHOP_ROOT}/bin/.checkpoint-api-syncagent" ]]; then
     echo "🚀 Downloading api-syncagent"
     curl -L "https://github.com/kcp-dev/api-syncagent/releases/download/v0.2.0-alpha.1/api-syncagent_0.2.0-alpha.1_${GOOS}_${GOARCH}.tar.gz" \
-      | tar -C "${workshop_root}/bin" -xzf - api-syncagent
-    touch "${workshop_root}/bin/.checkpoint-api-syncagent"
+      | tar -C "${WORKSHOP_ROOT}/bin" -xzf - api-syncagent
+    touch "${WORKSHOP_ROOT}/bin/.checkpoint-api-syncagent"
 fi
 
-if [[ ! -f "${workshop_root}/bin/.checkpoint-mcp-example-crd" ]]; then
+if [[ ! -f "${WORKSHOP_ROOT}/bin/.checkpoint-mcp-example-crd" ]]; then
     echo "🚀 Downloading KCP's mcp-example-crd"
     curl -L "https://github.com/mjudeikis/kcp-multicluster-provider-example/releases/download/v0.0.4/kcp-multicluster-provider-example_0.0.4_${GOOS}_${GOARCH}.tar.gz" \
-      | tar -C "${workshop_root}/bin" -xzf - mcp-example-crd
-    touch "${workshop_root}/bin/.checkpoint-mcp-example-crd"
+      | tar -C "${WORKSHOP_ROOT}/bin" -xzf - mcp-example-crd
+    touch "${WORKSHOP_ROOT}/bin/.checkpoint-mcp-example-crd"
 fi
 
-if [[ ! -f "${workshop_root}/bin/.checkpoint-kind" ]]; then
+if [[ ! -f "${WORKSHOP_ROOT}/bin/.checkpoint-kind" ]]; then
   echo "🚀 Downloading kind"
-  curl -Lo "${workshop_root}/bin/kind" "https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-${GOOS}-${GOARCH}"
-  chmod +x "${workshop_root}/bin/kind"
-  touch "${workshop_root}/bin/.checkpoint-kind"
+  curl -Lo "${WORKSHOP_ROOT}/bin/kind" "https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-${GOOS}-${GOARCH}"
+  chmod +x "${WORKSHOP_ROOT}/bin/kind"
+  touch "${WORKSHOP_ROOT}/bin/.checkpoint-kind"
 fi
 
-if [[ ! -f "${workshop_root}/bin/.checkpoint-kubectl" ]]; then
+if [[ ! -f "${WORKSHOP_ROOT}/bin/.checkpoint-kubectl" ]]; then
   echo "🚀 Downloading kubectl"
-  curl -Lo "${workshop_root}/bin/kubectl" "https://dl.k8s.io/v1.31.6/bin/${GOOS}/${GOARCH}/kubectl"
-  chmod +x "${workshop_root}/bin/kubectl"
-  touch "${workshop_root}/bin/.checkpoint-kubectl"
+  curl -Lo "${WORKSHOP_ROOT}/bin/kubectl" "https://dl.k8s.io/v1.31.7/bin/${GOOS}/${GOARCH}/kubectl"
+  chmod +x "${WORKSHOP_ROOT}/bin/kubectl"
+  touch "${WORKSHOP_ROOT}/bin/.checkpoint-kubectl"
 fi
 
-if [[ ! -f "${workshop_root}/bin/.checkpoint-kubectl-krew" ]]; then
+if [[ ! -f "${WORKSHOP_ROOT}/bin/.checkpoint-kubectl-krew" ]]; then
   echo "🚀 Downloading kubectl-krew"
   curl -L "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew-${GOOS}_${GOARCH}.tar.gz" \
-    | tar -xzf - --strip-components=1 -C "${workshop_root}/bin" "./krew-${GOOS}_${GOARCH}"
-  mv "${workshop_root}/bin/krew-${GOOS}_${GOARCH}" "${workshop_root}/bin/kubectl-krew"
-  touch "${workshop_root}/bin/.checkpoint-kubectl-krew"
+    | tar -xzf - --strip-components=1 -C "${WORKSHOP_ROOT}/bin" "./krew-${GOOS}_${GOARCH}"
+  mv "${WORKSHOP_ROOT}/bin/krew-${GOOS}_${GOARCH}" "${WORKSHOP_ROOT}/bin/kubectl-krew"
+  touch "${WORKSHOP_ROOT}/bin/.checkpoint-kubectl-krew"
 fi
 
-"${workshop_root}/00-prerequisites/99-highfive.sh"
+"${EXERCISE_DIR}/99-highfive.sh"

--- a/20250401-kubecon-london/workshop/00-prerequisites/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/00-prerequisites/99-highfive.sh
@@ -3,8 +3,7 @@
 set -o nounset
 set -o pipefail
 
-workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export PATH="${workshop_root}/bin:${PATH}"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
 
 function check_exec {
   prog="${1}"
@@ -20,6 +19,6 @@ check_exec "kind" "version"
 check_exec "kubectl" "version --client"
 check_exec "kubectl-krew" "version"
 check_exec "mcp-example-crd" "-h" 2> /dev/null
-touch "${workshop_root}/.checkpoint-00"
+touch "${WORKSHOP_ROOT}/.checkpoint-00"
 
 printf "\n\t🥳 High-five! Move onto the first exercise!\n\n"

--- a/20250401-kubecon-london/workshop/01-deploy-kcp/01-start-kcp.sh
+++ b/20250401-kubecon-london/workshop/01-deploy-kcp/01-start-kcp.sh
@@ -4,12 +4,9 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export PATH="${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
 
-[[ -f "${workshop_root}/.checkpoint-00" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-00" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 function try_with_timeout {
   attempts=15
@@ -22,20 +19,20 @@ function try_with_timeout {
   exit 1
 }
 
-pgrep kcp &> /dev/null && { "${workshop_root}/01-deploy-kcp/99-highfive.sh" ; exit $? ; }
+pgrep kcp &> /dev/null && { "${EXERCISE_DIR}/99-highfive.sh" ; exit $? ; }
 
-cd "${workshop_root}"
+cd "${WORKSHOP_ROOT}"
 
 kcp start & kcp_pid=$!
 trap 'kill -TERM ${kcp_pid}' TERM INT EXIT
+export KUBECONFIG="${WORKSHOP_ROOT}/.kcp/admin.kubeconfig"
 try_with_timeout
 
 mkdir -p "${KUBECONFIGS_DIR}"
-cp "${workshop_root}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/admin.kubeconfig"
-# Create a kubeconfig for the sync-agent just in case we need it
-cp "${workshop_root}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/sync-agent.kubeconfig"
 
-cp "${workshop_root}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/mcp-controller.kubeconfig"
+cp "${WORKSHOP_ROOT}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/admin.kubeconfig"
+cp "${WORKSHOP_ROOT}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/sync-agent.kubeconfig"
+cp "${WORKSHOP_ROOT}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/mcp-controller.kubeconfig"
 
-"${workshop_root}/01-deploy-kcp/99-highfive.sh"
+"${EXERCISE_DIR}/99-highfive.sh"
 wait "${kcp_pid}"

--- a/20250401-kubecon-london/workshop/01-deploy-kcp/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/01-deploy-kcp/99-highfive.sh
@@ -3,12 +3,11 @@
 set -o nounset
 set -o pipefail
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export PATH="${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
 
 kubectl version &> /dev/null || { printf "\n\t❌It seems kcp is down :( !\n\n" ; exit 1 ; }
 printf "\t ✅ kcp is up and running!\n"
-touch "${workshop_root}/.checkpoint-01"
+touch "${WORKSHOP_ROOT}/.checkpoint-01"
 
 printf "\n\t🥳 High-five! Move onto the second exercise!\n\n"

--- a/20250401-kubecon-london/workshop/02-explore-workspaces/00-install-krew-plugins.sh
+++ b/20250401-kubecon-london/workshop/02-explore-workspaces/00-install-krew-plugins.sh
@@ -4,12 +4,9 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
 
-[[ -f "${workshop_root}/.checkpoint-01" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-01" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 [[ -z "$(kubectl krew index list | grep 'github.com/kcp-dev/krew-index.git')" ]] \
   && kubectl krew index add kcp-dev https://github.com/kcp-dev/krew-index.git

--- a/20250401-kubecon-london/workshop/02-explore-workspaces/01-create-apis.sh
+++ b/20250401-kubecon-london/workshop/02-explore-workspaces/01-create-apis.sh
@@ -4,21 +4,18 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
+export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
 
-[[ -f "${workshop_root}/.checkpoint-01" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-01" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 ::kubectl::ws::use ":"
 
 ::kubectl::ws::create_enter "providers" "root:organization"
 ::kubectl::ws::create_enter "cowboys" "root:universal"
 
-::kubectl::create_from_file "${exercise_dir}/apis/apiresourceschema.yaml"
-::kubectl::create_from_file "${exercise_dir}/apis/apiexport.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/apiresourceschema.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/apiexport.yaml"
 
 printf "\n\t🥳 Provider APIs created successfully! Continue with the next step, creating consumers! 💪\n\n"

--- a/20250401-kubecon-london/workshop/02-explore-workspaces/02-create-consumers.sh
+++ b/20250401-kubecon-london/workshop/02-explore-workspaces/02-create-consumers.sh
@@ -4,14 +4,11 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
+export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
 
-[[ -f "${workshop_root}/.checkpoint-01" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-01" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 ::kubectl::ws::use ":"
 
@@ -19,11 +16,11 @@ source "${workshop_root}/lib/kubectl.sh"
 ::kubectl::ws::create_enter "wild-west" "root:universal"
 ::kubectl::kcp::bind_with_permission_claims "root:providers:cowboys" "cowboys" "cowboys-consumer" "configmaps.core" ""
 
-::kubectl::create_from_file "${exercise_dir}/apis/consumer-wild-west.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/consumer-wild-west.yaml"
 
 ::kubectl::ws::use :root:consumers
 ::kubectl::ws::create_enter "wild-north" "root:universal"
 ::kubectl::kcp::bind_with_permission_claims "root:providers:cowboys" "cowboys" "cowboys-consumer" "configmaps.core" ""
-::kubectl::create_from_file "${exercise_dir}/apis/consumer-wild-north.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/consumer-wild-north.yaml"
 
-"${workshop_root}/02-explore-workspaces/99-highfive.sh"
+"${EXERCISE_DIR}/99-highfive.sh"

--- a/20250401-kubecon-london/workshop/02-explore-workspaces/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/02-explore-workspaces/99-highfive.sh
@@ -3,29 +3,28 @@
 set -o nounset
 set -o pipefail
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export PATH="${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
+export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
 
-::kubectl::ws::use ":" > /dev/null
+kubectl ws use ":" > /dev/null
 kubectl get ws consumers > /dev/null
 kubectl get ws providers > /dev/null
 
-::kubectl::ws::use ":root:providers" > /dev/null
+kubectl ws use ":root:providers" > /dev/null
 kubectl get ws cowboys > /dev/null
 
-::kubectl::ws::use ":root:consumers" > /dev/null
+kubectl ws use ":root:consumers" > /dev/null
 kubectl get ws wild-north > /dev/null
 kubectl get ws wild-west > /dev/null
 
-::kubectl::ws::use ":root:consumers:wild-north" > /dev/null
+kubectl ws use ":root:consumers:wild-north" > /dev/null
 kubectl get apibinding cowboys-consumer > /dev/null
 
-::kubectl::ws::use ":root:consumers:wild-west" > /dev/null
+kubectl ws use ":root:consumers:wild-west" > /dev/null
 kubectl get apibinding cowboys-consumer > /dev/null
 
 printf "\n\t ✅ Cowboy APIBindings between consumer and provider workspaces exist!\n"
-touch "${workshop_root}/.checkpoint-02"
+touch "${WORKSHOP_ROOT}/.checkpoint-02"
 
 printf "\n\t🥳 High-five! Move onto the second exercise!\n\n"

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/00-run-provider-cluster.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/00-run-provider-cluster.sh
@@ -4,15 +4,11 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
-source "${workshop_root}/lib/kind.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
+source "${WORKSHOP_ROOT}/lib/kind.sh"
 
-[[ -f "${workshop_root}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 kind_cluster_name='provider'
 kind_kubeconfig="${KUBECONFIGS_DIR}/${kind_cluster_name}.kubeconfig"

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/01-deploy-postgres.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/01-deploy-postgres.sh
@@ -4,21 +4,17 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
-[[ -f "${workshop_root}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 export KUBECONFIG="${KUBECONFIGS_DIR}/provider.kubeconfig"
 kind_cluster_name='provider'
 
 ::kubectl::apply_from_file 'https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/releases/cnpg-1.25.1.yaml'
 ::kubectl::apply_from_file 'https://raw.githubusercontent.com/kcp-dev/api-syncagent/refs/heads/main/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml'
-::kubectl::apply_from_file "${exercise_dir}/apis/resources-cluster.yaml"
-::kubectl::apply_from_file "${exercise_dir}/apis/resources-database.yaml"
+::kubectl::apply_from_file "${EXERCISE_DIR}/apis/resources-cluster.yaml"
+::kubectl::apply_from_file "${EXERCISE_DIR}/apis/resources-database.yaml"
 
 printf "\n\t🥳 PostgreSQL is now running in kind cluster 'provider'! Continue with the next step: ! 💪\n\n" "${kind_cluster_name}"

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/02-create-provider.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/02-create-provider.sh
@@ -4,20 +4,16 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
-[[ -f "${workshop_root}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 export KUBECONFIG="${KUBECONFIGS_DIR}/sync-agent.kubeconfig"
 kind_cluster_name='provider'
 
 ::kubectl::ws::use ":root:providers"
 ::kubectl::ws::create_enter "database" "root:universal"
-::kubectl::create_from_file "${exercise_dir}/apis/export.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/export.yaml"
 
 printf "\n\t🥳 PostgreSQL is now running in kind cluster 'provider'! Continue with the next step: ! 💪\n\n" "${kind_cluster_name}"

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/03-create-consumer.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/03-create-consumer.sh
@@ -4,14 +4,10 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
-[[ -f "${workshop_root}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
 ::kubectl::ws::use ":root:consumers"

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/04-run-api-syncagent.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/04-run-api-syncagent.sh
@@ -4,18 +4,13 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
-source "${workshop_root}/lib/api-syncagent.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/api-syncagent.sh"
 
-[[ -f "${workshop_root}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 kind_cluster_name='provider'
-export KUBECONFIG="${KUBECONFIGS_DIR}/provider.kubeconfig"
+export KUBECONFIG="${KUBECONFIGS_DIR}/${kind_cluster_name}.kubeconfig"
 
 pgrep api-syncagent &> /dev/null \
   || ::apisyncagent "postgresql.cnpg.io" "${KUBECONFIGS_DIR}/sync-agent.kubeconfig" "default"

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/05-create-database.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/05-create-database.sh
@@ -4,26 +4,19 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
-source "${workshop_root}/lib/api-syncagent.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
-[[ -f "${workshop_root}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-02" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
 
 ::kubectl::ws::use ":root:consumers:pg"
 
-::kubectl::create_from_file "${exercise_dir}/apis/consumer-1-cluster.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/consumer-1-cluster.yaml"
 ::kubectl::wait "cluster/kcp" "condition=Ready=true" "5m"
 
-
-
-::kubectl::create_from_file "${exercise_dir}/apis/consumer-1-database.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/consumer-1-database.yaml"
 ::kubectl::wait "database/db-one" "jsonpath={.status.applied}=true" "5m"
 
-"${workshop_root}/03-dynamic-providers/99-highfive.sh"
+"${EXERCISE_DIR}/99-highfive.sh"

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/99-highfive.sh
@@ -4,10 +4,8 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export PATH="${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
 function try_or_err {
   shell_script="${1}"
@@ -28,5 +26,5 @@ try_or_err "kubectl get apibinding postgresql.cnpg.io" "APIBinding postgresql.cn
 try_or_err "kubectl wait cluster/kcp '--for=condition=Ready=true' --timeout=0" "kcp PostgreSQL cluster exists in the consumer workspace"
 try_or_err "kubectl wait database/db-one '--for=jsonpath={.status.applied}=true' --timeout=0" "db-one PostgreSQL database exists in the consumer workspace"
 
-touch "${workshop_root}/.checkpoint-03"
+touch "${WORKSHOP_ROOT}/.checkpoint-03"
 printf "\n\t🥳 High-five! Move onto the fourth exercise!\n\n"

--- a/20250401-kubecon-london/workshop/04-application-providers/01-create-provider.sh
+++ b/20250401-kubecon-london/workshop/04-application-providers/01-create-provider.sh
@@ -4,19 +4,15 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
-[[ -f "${workshop_root}/.checkpoint-03" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-03" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 export KUBECONFIG="${KUBECONFIGS_DIR}/mcp-controller.kubeconfig"
 ::kubectl::ws::use ":root:providers"
 ::kubectl::ws::create_enter "application" "root:universal"
-::kubectl::create_from_file "${exercise_dir}/apis/apiresourceschema.yaml"
-::kubectl::create_from_file "${exercise_dir}/apis/export.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/apiresourceschema.yaml"
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/export.yaml"
 
 printf "\n\t🥳 You are good to go! \n"

--- a/20250401-kubecon-london/workshop/04-application-providers/02-consumer.sh
+++ b/20250401-kubecon-london/workshop/04-application-providers/02-consumer.sh
@@ -4,22 +4,13 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
-[[ -f "${workshop_root}/.checkpoint-03" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-03" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
 
 ::kubectl::ws::use ":root:consumers:pg"
-# TODO: add flag to accept secrets
-# ::kubectl::kcp::bind_apiexport "root:providers:application" "apis.contrib.kcp.io" "apis.contrib.kcp.io"
 ::kubectl::kcp::bind_with_permission_claims "root:providers:application" "apis.contrib.kcp.io" "apis.contrib.kcp.io" "secrets.core" ""
-::kubectl::create_from_file "${exercise_dir}/apis/application.yaml"
-
-# TODO(Add how to port forward from the application)
-
+::kubectl::create_from_file "${EXERCISE_DIR}/apis/application.yaml"

--- a/20250401-kubecon-london/workshop/04-application-providers/03-run-mcp.sh
+++ b/20250401-kubecon-london/workshop/04-application-providers/03-run-mcp.sh
@@ -6,6 +6,7 @@ set -o errexit
 
 source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
 source "${WORKSHOP_ROOT}/lib/kubectl.sh"
+source "${WORKSHOP_ROOT}/lib/mcp-example-crd.sh"
 
 [[ -f "${WORKSHOP_ROOT}/.checkpoint-03" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
@@ -13,5 +14,4 @@ export KUBECONFIG="${KUBECONFIGS_DIR}/mcp-controller.kubeconfig"
 ::kubectl::ws::use ":root:providers:application"
 
 pgrep mcp-example-crd &> /dev/null \
-  || mcp-example-crd --server=$(kubectl get apiexport apis.contrib.kcp.io -o jsonpath="{.status.virtualWorkspaces[0].url}") \
-    --provider-kubeconfig ${KUBECONFIGS_DIR}/provider.kubeconfig
+  || ::mcpexamplecrd "$(kubectl get apiexport apis.contrib.kcp.io -o jsonpath='{.status.virtualWorkspaces[0].url}')" "${KUBECONFIGS_DIR}/provider.kubeconfig"

--- a/20250401-kubecon-london/workshop/04-application-providers/03-run-mcp.sh
+++ b/20250401-kubecon-london/workshop/04-application-providers/03-run-mcp.sh
@@ -4,14 +4,10 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-export exercise_dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${workshop_root}/lib/kubectl.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kubectl.sh"
 
-[[ -f "${workshop_root}/.checkpoint-03" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
+[[ -f "${WORKSHOP_ROOT}/.checkpoint-03" ]] || { printf "\n\t📜 You need to complete the previous exercise!\n\n" ; exit 1 ; }
 
 export KUBECONFIG="${KUBECONFIGS_DIR}/mcp-controller.kubeconfig"
 ::kubectl::ws::use ":root:providers:application"

--- a/20250401-kubecon-london/workshop/04-application-providers/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/04-application-providers/99-highfive.sh
@@ -3,8 +3,4 @@
 set -o nounset
 set -o pipefail
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export PATH="${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
-
-
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"

--- a/20250401-kubecon-london/workshop/clean-all.sh
+++ b/20250401-kubecon-london/workshop/clean-all.sh
@@ -10,6 +10,7 @@ source "${WORKSHOP_ROOT}/lib/kind.sh"
 set +o errexit
 
 pkill api-syncagent && echo "🥷 stopped api-syncagent"
+pkill mcp-example-crd && echo "🥷 stopped mcp-example-crd"
 pkill kcp && echo "🥷 stopped kcp"
 
 ::kind::delete::cluster "provider"

--- a/20250401-kubecon-london/workshop/clean-all.sh
+++ b/20250401-kubecon-london/workshop/clean-all.sh
@@ -4,19 +4,16 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export PATH="${workshop_root}/bin:${PATH}"
-export KUBECONFIGS_DIR="${workshop_root}/kubeconfigs"
-source "${workshop_root}/lib/kind.sh"
+source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+source "${WORKSHOP_ROOT}/lib/kind.sh"
 
 set +o errexit
 
 pkill api-syncagent && echo "🥷 stopped api-syncagent"
 pkill kcp && echo "🥷 stopped kcp"
 
-kind_cluster_name='provider'
-::kind::delete::cluster "${kind_cluster_name}"
+::kind::delete::cluster "provider"
 
 rm -rf "${KUBECONFIGS_DIR}"
-rm ${workshop_root}/.checkpoint-*
-rm -rf ${workshop_root}/.kcp
+rm ${WORKSHOP_ROOT}/.checkpoint-*
+rm -rf ${WORKSHOP_ROOT}/.kcp

--- a/20250401-kubecon-london/workshop/lib/api-syncagent.sh
+++ b/20250401-kubecon-london/workshop/lib/api-syncagent.sh
@@ -4,10 +4,6 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-
 function ::apisyncagent {
   apiexport_name="${1}"
   kcp_kubeconfig="${2}"

--- a/20250401-kubecon-london/workshop/lib/env.sh
+++ b/20250401-kubecon-london/workshop/lib/env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+parent_path="${1}"
+
+export WORKSHOP_ROOT="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
+export KREW_ROOT="${WORKSHOP_ROOT}/bin/.krew"
+export PATH="${WORKSHOP_ROOT}/bin/.krew/bin:${WORKSHOP_ROOT}/bin:${PATH}"
+export KUBECONFIGS_DIR="${WORKSHOP_ROOT}/kubeconfigs"
+export EXERCISE_DIR="${parent_path}"

--- a/20250401-kubecon-london/workshop/lib/kind.sh
+++ b/20250401-kubecon-london/workshop/lib/kind.sh
@@ -4,11 +4,6 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
-
 kind_service_name='workshop-kcp-kind.scope'
 
 function ::kind::create::cluster {

--- a/20250401-kubecon-london/workshop/lib/kubectl.sh
+++ b/20250401-kubecon-london/workshop/lib/kubectl.sh
@@ -4,11 +4,6 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-export workshop_root="$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop"
-export KREW_ROOT="${workshop_root}/bin/.krew"
-export PATH="${workshop_root}/bin/.krew/bin:${workshop_root}/bin:${PATH}"
-export KUBECONFIG="${workshop_root}/.kcp/admin.kubeconfig"
-
 function ::kubectl::ws::use {
   path="${1}"
   printf "\n✨Switching to Workspace '${path}':\n"

--- a/20250401-kubecon-london/workshop/lib/mcp-example-crd.sh
+++ b/20250401-kubecon-london/workshop/lib/mcp-example-crd.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+function ::mcpexamplecrd {
+  server="${1}"
+  provider="${2}"
+  printf "\n✨Running mcp-example-crd, reconciling Application resource\n"
+  printf "  from '${server}' in provider '${provider}'\n"
+  printf "\$ mcp-example-crd --server "${apiexport_name}" --provider-kubeconfig "${provider}"\n"
+  mcp-example-crd --server "${apiexport_name}" --provider-kubeconfig "${provider}"
+}


### PR DESCRIPTION
This PR:

* consolidates all env exports into a single script and then reuses it
* renames exported env vars to uppercase

and some non-env related changes:
* clean-all.sh script now cleans up the mcp-example-crd process
* adds a wrapper for mcp-example-crd exec for consistency

Changes grouped into commits for easier review.