### PR TITLE
Use separate kubeconfig for check scripts

### DIFF
--- a/20250401-kubecon-london/workshop/01-deploy-kcp/01-start-kcp.sh
+++ b/20250401-kubecon-london/workshop/01-deploy-kcp/01-start-kcp.sh
@@ -31,6 +31,7 @@ try_with_timeout
 mkdir -p "${KUBECONFIGS_DIR}"
 
 cp "${WORKSHOP_ROOT}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/admin.kubeconfig"
+cp "${WORKSHOP_ROOT}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/internal-checkscript.kubeconfig"
 cp "${WORKSHOP_ROOT}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/sync-agent.kubeconfig"
 cp "${WORKSHOP_ROOT}/.kcp/admin.kubeconfig" "${KUBECONFIGS_DIR}/mcp-controller.kubeconfig"
 

--- a/20250401-kubecon-london/workshop/01-deploy-kcp/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/01-deploy-kcp/99-highfive.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
-export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
+export KUBECONFIG="${KUBECONFIGS_DIR}/internal-checkscript.kubeconfig"
 
 kubectl version &> /dev/null || { printf "\n\t❌It seems kcp is down :( !\n\n" ; exit 1 ; }
 printf "\t ✅ kcp is up and running!\n"

--- a/20250401-kubecon-london/workshop/02-explore-workspaces/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/02-explore-workspaces/99-highfive.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
 source "${WORKSHOP_ROOT}/lib/kubectl.sh"
-export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
+export KUBECONFIG="${KUBECONFIGS_DIR}/internal-checkscript.kubeconfig"
 
 kubectl ws use ":" > /dev/null
 kubectl get ws consumers > /dev/null

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/99-highfive.sh
@@ -20,7 +20,7 @@ export KUBECONFIG="${KUBECONFIGS_DIR}/provider.kubeconfig"
 try_or_err "kubectl api-resources" "provider cluster up and running"
 try_or_err "kubectl api-resources | grep postgresql.cnpg.io/v1" "PostgreSQL API available in provider cluster"
 
-export KUBECONFIG="${KUBECONFIGS_DIR}/admin.kubeconfig"
+export KUBECONFIG="${KUBECONFIGS_DIR}/internal-checkscript.kubeconfig"
 try_or_err "::kubectl::ws::use :root:consumers:pg" "Workspace :root:consumers:pg exists"
 try_or_err "kubectl get apibinding postgresql.cnpg.io" "APIBinding postgresql.cnpg.io in :root:consumers:pg exists"
 try_or_err "kubectl wait cluster/kcp '--for=condition=Ready=true' --timeout=0" "kcp PostgreSQL cluster exists in the consumer workspace"

--- a/20250401-kubecon-london/workshop/04-application-providers/99-highfive.sh
+++ b/20250401-kubecon-london/workshop/04-application-providers/99-highfive.sh
@@ -4,3 +4,4 @@ set -o nounset
 set -o pipefail
 
 source "$(git rev-parse --show-toplevel)/20250401-kubecon-london/workshop/lib/env.sh" "$(cd "$(dirname "$0")" && pwd)"
+export KUBECONFIG="${KUBECONFIGS_DIR}/internal-checkscript.kubeconfig"


### PR DESCRIPTION
Use a separate kubeconfig for check scripts to avoid changing current ws in admin.kubeconfig.